### PR TITLE
Add empty BST case for getNodeIndex method

### DIFF
--- a/src/main/java/searching/ArrayBSTDelete.java
+++ b/src/main/java/searching/ArrayBSTDelete.java
@@ -139,12 +139,14 @@ public class ArrayBSTDelete<Key extends Comparable<Key>, Value> {
      * NONE if not present
      */
     private int getNodeIndex(Key key) {
-        int i = 0;
-        while (i != NONE) {
-            int cmp = key.compareTo(keys.get(i));
-            if (cmp == 0) return i;
-            else if (cmp < 0) i = idxLeftNode.get(i);
-            else i = idxRightNode.get(i);
+        if (!keys.isEmpty()) {
+            int i = 0;
+            while (i != NONE) {
+                int cmp = key.compareTo(keys.get(i));
+                if (cmp == 0) return i;
+                else if (cmp < 0) i = idxLeftNode.get(i);
+                else i = idxRightNode.get(i);
+            }
         }
         return NONE;
     }


### PR DESCRIPTION
Fixed small error : calling `getNodeIndex()` on an empty BST should return `NONE` but threw an error because of a `get()` operation on an empty array. 